### PR TITLE
fix: rename flask to fastapi

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,12 +10,12 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="stylesheet" href="../static/styles.css">
-    <title>Hello Flask!</title>
+    <title>Hello FastAPI!</title>
 
 </head>
 
 <body class="mt-5">
-    <p class="fs-2 text-center text-success">Hello Flask!</p>
-    <p class="fs-6 text-center">Let's have some fun learning Flask!</p>
+    <p class="fs-2 text-center text-success">Hello FastAPI!</p>
+    <p class="fs-6 text-center">Let's have some fun learning FastAPI!</p>
     <a href="{{ url_for('get_tasks') }}">Tasks</a>
 </body>


### PR DESCRIPTION
Renamed flask to fastapi